### PR TITLE
Remove abbreviations that we don't use

### DIFF
--- a/CityGML/annex-glossary.adoc
+++ b/CityGML/annex-glossary.adoc
@@ -307,7 +307,7 @@ Volume is the measure of the physical space of any 3-D geometric object. +
 * ISO {nbsp}{nbsp}{nbsp}{nbsp}{nbsp} International Organization for Standardisation
 * ISO/TC 211 {nbsp}{nbsp}{nbsp}{nbsp}{nbsp} ISO Technical Committee 211
 * LOD {nbsp}{nbsp}{nbsp}{nbsp}{nbsp} Level of Detail
-* MQTT  {nbsp}{nbsp}{nbsp}{nbsp}{nbsp}
+* MQTT {nbsp}{nbsp}{nbsp}{nbsp}{nbsp}
 * OASIS {nbsp}{nbsp}{nbsp}{nbsp}{nbsp} Organisation for the Advancement of Structured Information Standards
 * OGC {nbsp}{nbsp}{nbsp}{nbsp}{nbsp} Open Geospatial Consortium
 * SIG 3D {nbsp}{nbsp}{nbsp}{nbsp}{nbsp} Special Interest Group 3D of the GDI-DE


### PR DESCRIPTION
In the "terms" section, should we cite OGC's Observations & Measurements, rather than the ISO one? That said, I think we only use these three terms via SensorThings?

We don't actually use "2D" even in the places where the Conceptual Model does (terrain, relief). A lot of these terms are only used in examples. 

"Terrain intersection curve" is never abbreviated in our document, although it is in the Conceptual Model. We only mention WFS in the bibliography, and not by using the abbreviation.