### PR TITLE
Remove 'bold' ("*") from two headings

### DIFF
--- a/CityGML/data-dictionaries/Appearance.adoc
+++ b/CityGML/data-dictionaries/Appearance.adoc
@@ -1,5 +1,5 @@
 [[Appearance-package-dd]]
-=== *Appearance*
+=== Appearance
 
 [cols="1,4",frame=none,grid=none]
 |===
@@ -8,7 +8,7 @@
 |{nbsp}{nbsp}{nbsp}{nbsp}Stereotype: | «ApplicationSchema»
 |===
 
-==== *Classes*
+==== Classes
 
 [[AbstractSurfaceData-section]]
 [cols="1a"]


### PR DESCRIPTION
Having "Appearance" and "Classes" directly bold (i.e. "*" before & after), in addition to being H3 ("===") is redundant and resulted in them appearing "bold" in the table of contents.